### PR TITLE
회원 엔티티 생성

### DIFF
--- a/auth/src/main/java/com/mongs/auth/entity/Member.java
+++ b/auth/src/main/java/com/mongs/auth/entity/Member.java
@@ -1,0 +1,34 @@
+package com.mongs.auth.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+@Builder(toBuilder = true)
+public class Member {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(updatable = false, nullable = false)
+    private String email;
+    @Column(nullable = false)
+    private String name;
+    @Column(updatable = false, nullable = false)
+    @CreatedDate
+    private LocalDateTime createdAt;
+    @Column(nullable = false)
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}


### PR DESCRIPTION
## 개요
- Member Entity 생성
- ```AuditingEntityListener``` 를 통해 객체의 변화를 감지하고. 생성/수정 일자를 수정하도록 구성

## 참고사항
- related issue: #15 