### PR TITLE
회원 레포지토리 생성 및 단위 테스트

### DIFF
--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -2,7 +2,6 @@ dependencies {
     // spring
     implementation 'org.springframework.boot:spring-boot-starter-web'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     // JPA
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -12,6 +11,9 @@ dependencies {
     implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+    // test
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.awaitility:awaitility:4.2.0'
 }
 
 tasks.register('copyPrivate', Copy) {

--- a/auth/src/main/java/com/mongs/auth/AuthApplication.java
+++ b/auth/src/main/java/com/mongs/auth/AuthApplication.java
@@ -2,8 +2,10 @@ package com.mongs.auth;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class AuthApplication {
 
     public static void main(String[] args) {

--- a/auth/src/main/java/com/mongs/auth/repository/MemberRepository.java
+++ b/auth/src/main/java/com/mongs/auth/repository/MemberRepository.java
@@ -1,0 +1,9 @@
+package com.mongs.auth.repository;
+
+import com.mongs.auth.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/auth/src/test/java/com/mongs/auth/repository/MemberRepositoryTest.java
+++ b/auth/src/test/java/com/mongs/auth/repository/MemberRepositoryTest.java
@@ -1,0 +1,86 @@
+package com.mongs.auth.repository;
+
+import com.mongs.auth.entity.Member;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+public class MemberRepositoryTest {
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("회원 id를 입력하지 않아도 id가 등록된다.")
+    void autoMemberId() {
+        // given
+        Member member = Member.builder()
+                .email("test@gmail.com")
+                .name("테스트 이름")
+                .build();
+
+        // when
+        Member saveMember = memberRepository.save(member);
+
+        // then
+        Long memberId = saveMember.getId();
+        assertThat(memberId).isNotNull();
+        assertThat(memberId).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("회원 가입 일자를 입력하지 않아도 가입일자가 등록된다.")
+    void autoCreatedAt() {
+        // given
+        Member member = Member.builder()
+                .email("test@gmail.com")
+                .name("테스트 이름")
+                .build();
+
+        LocalDateTime expected = LocalDateTime.now().plusSeconds(1);
+
+        // when
+        Member saveMember = memberRepository.save(member);
+
+        // then
+        LocalDateTime createdAt = saveMember.getCreatedAt();
+        assertThat(createdAt).isNotNull();
+        assertThat(createdAt).isBeforeOrEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("회원 정보를 수정하면 수정일자가 변경된다.")
+    void autoUpdatedAt() {
+        // given
+        Member member = Member.builder()
+                .email("test@gmail.com")
+                .name("테스트 이름")
+                .build();
+
+        member = memberRepository.save(member);
+        LocalDateTime createdAt = member.getCreatedAt();
+
+        int delaySeconds = 5;
+        Awaitility.await()
+                .pollDelay(Duration.ofSeconds(delaySeconds))
+                .until(() -> true);
+
+        LocalDateTime expected1 = createdAt.plusSeconds(delaySeconds);
+        LocalDateTime expected2 = LocalDateTime.now().plusSeconds(1);
+
+        // when
+        Member modifyMember = memberRepository.saveAndFlush(member.toBuilder().name("수정 테스트 이름").build());
+
+        // then
+        LocalDateTime updatedAt = modifyMember.getUpdatedAt();
+        assertThat(updatedAt).isAfterOrEqualTo(expected1);
+        assertThat(updatedAt).isBeforeOrEqualTo(expected2);
+    }
+}


### PR DESCRIPTION
## 개요
- 회원 레포지토리 생성
- 회원 엔티티의 id, createdAt (가입 일자), updatedAt (회원 정보 수정 일자) 자동 입력 단위 테스트 진행
- 딜레이 테스트 케이스를 위한 ```awaitility.org.awaitility:awaitility:4.2.0``` 의존성 추가

## 참고사항
- related issue: #16 