### PR TITLE
매치 퇴장 오류 수정

### DIFF
--- a/character-service/application/battle-application/src/main/java/com/monglife/mongs/application/battle/port/in/service/MatchService.java
+++ b/character-service/application/battle-application/src/main/java/com/monglife/mongs/application/battle/port/in/service/MatchService.java
@@ -105,20 +105,18 @@ public class MatchService implements MatchUseCase {
         Match match = matchPersistencePort.getMatchPort(command.getMatchId())
                 .orElseThrow(NotExistsMatchException::new);
 
-        if (match.isEnd()) {
-            throw new NotExistsMatchException();
-        }
+        if (!match.isEnd()) {
+            // 플레이어 퇴장
+            match.exitMatchPlayer(command.getPlayerId());
 
-        // 플레이어 퇴장
-        match.exitMatchPlayer(command.getPlayerId());
+            // 매치 정보 동기화
+            matchPersistencePort.saveMatchPort(match)
+                    .orElseThrow(NotExistsMatchException::new);
 
-        // 매치 정보 동기화
-        matchPersistencePort.saveMatchPort(match)
-                .orElseThrow(NotExistsMatchException::new);
-
-        // 매치가 중단된 경우 승리 매치 종료 비동기 응답
-        if (match.isAllMatchPlayersExited()) {
-            matchPublishPort.publishMatchEndPort(match);
+            // 매치가 중단된 경우 승리 매치 종료 비동기 응답
+            if (match.isAllMatchPlayersExited()) {
+                matchPublishPort.publishMatchEndPort(match);
+            }
         }
 
         return match;


### PR DESCRIPTION
## 개요
- 이미 종료된 매치 퇴장 시, 예외 발생 로직 수정
- 마지막 라운드 이후, 매치 종료 화면을 보지 않고 종료하는 경우에 이미 종료된 매치를 퇴장하려고 하여 예외 발생